### PR TITLE
Allow resolving a hostname to an IP at startup

### DIFF
--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+if [ -n "$STEAMCACHE_RESOLVE_NAME" ]
+then
+	RESOLVED_IP="$(nslookup "$STEAMCACHE_RESOLVE_NAME" 2>/dev/null | grep 'Address' | awk '{ print $3 }')"
+	if [ -n "$RESOLVED_IP" ]
+	then
+		echo "Resolved ${STEAMCACHE_RESOLVE_NAME} to ${RESOLVED_IP}"
+		STEAMCACHE_IP="$RESOLVED_IP"
+	else
+		echo "Failed to resolve ${STEAMCACHE_RESOLVE_NAME}; using ${STEAMCACHE_IP} instead" >&2
+	fi
+fi
+
 if [ -z "$STEAMCACHE_IP" ]
 then
 	echo "No value in \$STEAMCACHE_IP!" >&2


### PR DESCRIPTION
This allows the user to pass a hostname in via environment variable (STEAMCACHE_RESOLVE_NAME) to be resolved at startup.