### PR TITLE
Add support for steamcontent.com and steampipe.steamcontent.com

### DIFF
--- a/overlay/etc/bind/steamcache.conf
+++ b/overlay/etc/bind/steamcache.conf
@@ -12,3 +12,4 @@ zone "content5.steampowered.com" in { type master; file "/etc/bind/steamcache/db
 zone "content6.steampowered.com" in { type master; file "/etc/bind/steamcache/db.content_.steampowered.com"; };
 zone "content7.steampowered.com" in { type master; file "/etc/bind/steamcache/db.content_.steampowered.com"; };
 zone "content8.steampowered.com" in { type master; file "/etc/bind/steamcache/db.content_.steampowered.com"; };
+zone "steampipe.steampowered.com" in { type master; file "/etc/bind/steamcache/steamcontent.com"; };

--- a/overlay/etc/bind/steamcache/template.db.steamcontent.com
+++ b/overlay/etc/bind/steamcache/template.db.steamcontent.com
@@ -1,0 +1,14 @@
+$ORIGIN steamcontent.com.
+$TTL	600
+@		IN	SOA	ns1 dns.steamcache.net. (
+			2016060800
+			604800
+			600
+			600
+			600 )
+@		IN	NS	ns1
+ns1		IN	A	{{ steamcache_ip }}
+steamcache	IN	A	{{ steamcache_ip }}
+
+*		IN	CNAME	steamcache.steamcontent.com.
+*.steampipe	IN	CNAME	steamcache.steamcontent.com.

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -20,9 +20,11 @@ fi
 
 cp /etc/bind/steamcache/template.db.content_.steampowered.com /etc/bind/steamcache/db.content_.steampowered.com
 cp /etc/bind/steamcache/template.db.cs.steampowered.com /etc/bind/steamcache/db.cs.steampowered.com
+cp /etc/bind/steamcache/template.db.steamcontent.com /etc/bind/steamcache/db.steamcontent.com
 
 sed -i -e "s%{{ steamcache_ip }}%$STEAMCACHE_IP%g" /etc/bind/steamcache/db.content_.steampowered.com
 sed -i -e "s%{{ steamcache_ip }}%$STEAMCACHE_IP%g" /etc/bind/steamcache/db.cs.steampowered.com
+sed -i -e "s%{{ steamcache_ip }}%$STEAMCACHE_IP%g" /etc/bind/steamcache/db.steamcontent.com
 
 /usr/sbin/named -u named -c /etc/bind/named.conf -f
 


### PR DESCRIPTION
Valve made a change sometime after May that changed CDN domains to steamcontent.com and steampipe.steamcontent.com. This adds support to the DNS container - this will require modification of the steamcache and generic containers (pull requests coming soon).