### PR TITLE
Fix the config for steamcontent.com

### DIFF
--- a/overlay/etc/bind/steamcache.conf
+++ b/overlay/etc/bind/steamcache.conf
@@ -12,4 +12,4 @@ zone "content5.steampowered.com" in { type master; file "/etc/bind/steamcache/db
 zone "content6.steampowered.com" in { type master; file "/etc/bind/steamcache/db.content_.steampowered.com"; };
 zone "content7.steampowered.com" in { type master; file "/etc/bind/steamcache/db.content_.steampowered.com"; };
 zone "content8.steampowered.com" in { type master; file "/etc/bind/steamcache/db.content_.steampowered.com"; };
-zone "steampipe.steampowered.com" in { type master; file "/etc/bind/steamcache/steamcontent.com"; };
+zone "steamcontent.com" in { type master; file "/etc/bind/steamcache/db.steamcontent.com"; };


### PR DESCRIPTION
Since steam only uses *.steampipe.steamcontent.com for downloading, nothing was cached because there were some typos in the named config.