### PR TITLE
Add missing Blizzard hostnames

### DIFF
--- a/overlay/etc/bind/cache.conf
+++ b/overlay/etc/bind/cache.conf
@@ -8,6 +8,8 @@
 #ENABLE_BLIZZARD#zone "blizzard.vo.llnwd.net" in { type master; file "/etc/bind/cache/blizzard/db.blizzard"; };
 #ENABLE_BLIZZARD#zone "blzddist1-a.akamaihd.net" in { type master; file "/etc/bind/cache/blizzard/db.blizzard"; };
 #ENABLE_BLIZZARD#zone "blzddist2-a.akamaihd.net" in { type master; file "/etc/bind/cache/blizzard/db.blizzard"; };
+#ENABLE_BLIZZARD#zone "blzddist3-a.akamaihd.net" in { type master; file "/var/lib/bind/db.blizzard"; };
+#ENABLE_BLIZZARD#zone "level3.blizzard.com" in { type master; file "/var/lib/bind/db.blizzard"; };
 
 ## Frontier
 #ENABLE_FRONTIER#zone "cdn.zaonce.net" in { type master; file "/etc/bind/cache/frontier/db.frontier"; };

--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -6,11 +6,7 @@ options {
         allow-query { any; };
         allow-query-cache { any; };
         listen-on { any; };
-        listen-on-v6 { any; };
-        forwarders {
-                208.67.222.222;
-                208.67.220.220;
-        };        
+        listen-on-v6 { any; };       
 };
 
 logging {

--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -7,6 +7,10 @@ options {
         allow-query-cache { any; };
         listen-on { any; };
         listen-on-v6 { any; };
+        forwarders {
+                208.67.222.222;
+                208.67.220.220;
+        };        
 };
 
 logging {

--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -6,7 +6,7 @@ options {
         allow-query { any; };
         allow-query-cache { any; };
         listen-on { any; };
-        listen-on-v6 { any; };       
+        listen-on-v6 { any; };
 };
 
 logging {


### PR DESCRIPTION
When using this i found Battle.net would half use my cache and half download from their servers. After adding these two entries which i found on other DNS Caches for blizzard the problem was resolved.