### PR TITLE
Add variable to disable Bind DNSSEC validation

### DIFF
--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -1,6 +1,6 @@
 options {
         directory "/var/cache/bind";
-        dnssec-validation auto;
+        dnssec-validation no;
         auth-nxdomain no;    # conform to RFC1035
         allow-recursion { any; };
         allow-query { any; };

--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -1,6 +1,6 @@
 options {
         directory "/var/cache/bind";
-        dnssec-validation no;
+        dnssec-validation auto;
         auth-nxdomain no;    # conform to RFC1035
         allow-recursion { any; };
         allow-query { any; };

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -139,6 +139,11 @@ if ! [ -z "${UPSTREAM_DNS}" ] ; then
   sed -i "s/#ENABLE_UPSTREAM_DNS#//;s/dns_ip/${UPSTREAM_DNS}/" /etc/bind/named.conf.options
 fi
 
+if ! [ -z "${DISABLE_DNSSEC_VALIDATION}" ] ; then
+  sed -i "s/dnssec_validation//;s/auto/no/" /etc/bind/named.conf.options
+  echo "Disabling dnssec validation"
+fi
+
 echo "finished bootstrapping."
 
 echo ""


### PR DESCRIPTION
When UPSTREAM_DNS is set to a DNS server that does not support DNSSEC or does not imlement it correctly, bind reports SERVFAIL on DNS requests that are forwarded to UPSTREAM_DNS.
Disabling dnssec validation by setting dnssec_validation to no in /etc/bind/named.conf.options solves this.
Adding a new variable to bootstrap.sh to change this setting on user request.
Tested with Windows Server 2012 R2 and 2016 DNS and dnsmasq on linux. Default google dns 8.8.8.8 supports dnssec.
Reproduce by pointing UPSTREAM_DNS at non-dnssec server and running "nslookup <domain> <container_ip>". Observe Servfail message in container logs. 