### PR TITLE
Disable dnssec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 MAINTAINER SteamCache.Net Team <team@steamcache.net>
 
-ENV STEAMCACHE_DNS_VERSION 1
+ENV STEAMCACHE_DNS_VERSION=1 ENABLE_DNSSEC_VALIDATION=false
 
 RUN	apk update && apk add			\
 		bind	\

--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -1,6 +1,6 @@
 options {
         directory "/var/cache/bind";
-        dnssec-validation auto;
+        dnssec-validation no;
         auth-nxdomain no;    # conform to RFC1035
         allow-recursion { any; };
         allow-query { any; };

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -142,9 +142,9 @@ if ! [ -z "${UPSTREAM_DNS}" ] ; then
   sed -i "s/#ENABLE_UPSTREAM_DNS#//;s/dns_ip/${UPSTREAM_DNS}/" /etc/bind/named.conf.options
 fi
 
-if ! [ -z "${DISABLE_DNSSEC_VALIDATION}" ] ; then
-  sed -i "s/dnssec_validation//;s/auto/no/" /etc/bind/named.conf.options
-  echo "Disabling dnssec validation"
+if [ "${ENABLE_DNSSEC_VALIDATION}" = true ] ; then
+	echo "Enabling dnssec validation"
+	sed -i "s/dnssec-validation no/dnssec-validation auto/" /etc/bind/named.conf.options
 fi
 
 echo "finished bootstrapping."


### PR DESCRIPTION
Disabled DNSSEC validation with an option to reenable it

This is a rework of PR #50 to change from an optional disable to a mandatory disable with an option enable