### PR TITLE
Add support for multiple ips to resolve slow steam downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 MAINTAINER SteamCache.Net Team <team@steamcache.net>
 
-ENV STEAMCACHE_DNS_VERSION=1 ENABLE_DNSSEC_VALIDATION=false
+ENV STEAMCACHE_DNS_VERSION=1 ENABLE_DNSSEC_VALIDATION=false LANCACHE_DNSDOMAIN=cache.steamcache.net
 
 RUN	apk update && apk add			\
 		bind	\

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ docker run --name steamcache-dns -p 10.0.0.2:53:53/udp -e STEAMCACHE_IP=10.0.0.3
 This will add a forwarder for all queries not served by steamcache to be sent to the upstream DNS server, in this case Google's DNS.  If
 you have a DNS server on 1.2.3.4, the command argument would be `-e UPSTREAM_DNS=1.2.3.4`.
 
+## Multiple IPs
+
+Should you wish a cache server to have multiple IP addresses (for example a monolithic instance tuned for steam) you may specify them as a space delimited list within quotes for example: `-e STEAMCACHE_IP="1.2.3.4 5.6.7.8"`
 
 ## Running on Startup
 
@@ -72,7 +75,7 @@ More information can be found at the [SteamCache github page](http://steamcache.
 
 The MIT License (MIT)
 
-Copyright (c) 2015-2017 Jessica Smith, Robin Lewis, Brian Wojtczak, Jason Rivers
+Copyright (c) 2015-2017 Jessica Smith, Robin Lewis, Brian Wojtczak, Jason Rivers, James Kinsman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -8,6 +8,7 @@ options {
         listen-on { any; };
         listen-on-v6 { any; };
 		response-policy { zone "rpz"; };
+		rrset-order { order cyclic; };
         #ENABLE_UPSTREAM_DNS#forwarders { dns_ip; };
 };
 

--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -7,6 +7,7 @@ options {
         allow-query-cache { any; };
         listen-on { any; };
         listen-on-v6 { any; };
+		response-policy { zone "rpz"; };
         #ENABLE_UPSTREAM_DNS#forwarders { dns_ip; };
 };
 

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -103,11 +103,12 @@ cat services.json | jq -r '.cache_domains[] | .name, .domain_files[]' | while re
 			SERVICE_ENABLED=true	
 		fi
 	else
+		echo "testing for presence of ${SERVICEUC}CACHE_IP"
     	if env | grep "${SERVICEUC}CACHE_IP" >/dev/null 2>&1; then
 			SERVICE_ENABLED=true
 		fi
 	fi
-	if [ $SERVICE_ENABLED ]; then
+	if [ "$SERVICE_ENABLED" == "true" ]; then
     	if env | grep "${SERVICEUC}CACHE_IP" >/dev/null 2>&1; then
     		C_IP=$(env | grep "${SERVICEUC}CACHE_IP=" | sed 's/.*=//')
     	else
@@ -129,7 +130,7 @@ cat services.json | jq -r '.cache_domains[] | .name, .domain_files[]' | while re
 	fi
 
   else
-	if [ $CONTINUE ]; then
+	if [ "$CONTINUE" == "true" ]; then
 
       curl -s -o ${L} https://raw.githubusercontent.com/uklans/cache-domains/master/${L}
     	## files don't have a newline at the end

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -6,6 +6,9 @@ ZONEPATH="/etc/bind/cache/"
 ZONETEMPLATE="/etc/bind/cache/zone.tmpl"
 CACHECONF="/etc/bind/cache.conf"
 USE_GENERIC_CACHE="${USE_GENERIC_CACHE:-false}"
+LANCACHE_DNSDOMAIN="${LANCACHE_DNSDOMAIN:-cache.steamcache.net}"
+CACHE_ZONE="${ZONEPATH}$LANCACHE_DNSDOMAIN.db"
+RPZ_ZONE="${ZONEPATH}rpz.db"
 
 echo "     _                                      _                       _   "
 echo "    | |                                    | |                     | |  "
@@ -41,9 +44,7 @@ if [ "$USE_GENERIC_CACHE" = "true" ]; then
     echo ""
     echo "----------------------------------------------------------------------"
     echo "Using Generic Server: ${LANCACHE_IP}"
-    echo "Make sure you are using a load balancer at ${LANCACHE_IP}"
-    echo "it is not recommended to use a single cache server for all services"
-    echo "as you will get cache clashes."
+    echo "Make sure you are using a monolithic cache or load balancer at ${LANCACHE_IP}"
     echo "----------------------------------------------------------------------"
     echo ""
 fi
@@ -51,52 +52,94 @@ fi
 rm -f ${CACHECONF}
 touch ${CACHECONF}
 
+#Add the rpz zones to the cache.conf
+echo "
+	zone \"$LANCACHE_DNSDOMAIN\" {
+		type master;
+		file \"$CACHE_ZONE\";
+	};
+    zone \"rpz\" {
+      type master;
+      file \"$RPZ_ZONE\";
+      allow-query { none; };
+    };" > ${CACHECONF}
+
+#Generate the SOA for cache.steamcache.net
+
+echo "\$ORIGIN $LANCACHE_DNSDOMAIN. 
+\$TTL    600
+@       IN  SOA localhost. dns.steamcache.net. (
+             $(date +%s)
+             604800
+             600
+             600
+             600 )
+@       IN  NS  localhost.
+
+" > $CACHE_ZONE
+
+#Generate the RPZ zone file
+
+echo "\$TTL 60
+@            IN    SOA  localhost. root.localhost.  (
+                          2   ; serial 
+                          3H  ; refresh 
+                          1H  ; retry 
+                          1W  ; expiry 
+                          1H) ; minimum 
+                  IN    NS    localhost." > $RPZ_ZONE
+
 curl -s -o services.json https://raw.githubusercontent.com/uklans/cache-domains/master/cache_domains.json
 
 cat services.json | jq -r '.cache_domains[] | .name, .domain_files[]' | while read L; do
   if ! echo ${L} | grep "\.txt" >/dev/null 2>&1 ; then
-#    if [ "${L}" = "steam" ]; then
-#      set -x
-#    else
-#      set +x
-#    fi
     SERVICE=${L}
     SERVICEUC=`echo ${L} | tr [:lower:] [:upper:]`
-    if ! env | grep "DISABLE_${SERVICEUC}=true" >/dev/null 2>&1; then
-      if env | grep "${SERVICEUC}CACHE_IP" >/dev/null 2>&1; then
-        C_IP=$(env | grep "${SERVICEUC}CACHE_IP=" | sed 's/.*=//')
-      else
-        C_IP=${LANCACHE_IP}
-      fi
-      if [ "$USE_GENERIC_CACHE" = "true" ] && ! [ -z "${C_IP}" ] ; then
-        echo "Setting up ${SERVICE} -> ${C_IP}"
-      else
-        echo "Creating ${SERVICE} template"
-      fi
-      echo "## ${SERVICE}" >> ${CACHECONF}
-    fi
-  else
+	echo "Processing service: $SERVICE"
+	CONTINUE=false
+	SERVICE_ENABLED=false
+	if [ "$USE_GENERIC_CACHE" = "true" ]; then
+    	if ! env | grep "DISABLE_${SERVICEUC}=true" >/dev/null 2>&1; then
+			SERVICE_ENABLED=true	
+		fi
+	else
+    	if env | grep "${SERVICEUC}CACHE_IP" >/dev/null 2>&1; then
+			SERVICE_ENABLED=true
+		fi
+	fi
+	if [ $SERVICE_ENABLED ]; then
+    	if env | grep "${SERVICEUC}CACHE_IP" >/dev/null 2>&1; then
+    		C_IP=$(env | grep "${SERVICEUC}CACHE_IP=" | sed 's/.*=//')
+    	else
+    		C_IP=${LANCACHE_IP}
+    	fi
+		if [ "x$C_IP" != "x" ]; then
+			echo "Enabling service with ip(s): $C_IP";
+			for IP in $C_IP; do
+				echo "$SERVICE IN A $IP;" >> $CACHE_ZONE
+			done
+      		echo ";## ${SERVICE}" >> ${RPZ_ZONE}
+			CONTINUE=true
+		else
+			echo "Could not find IP for requested service: $SERVICE"
+			exit 1
+		fi
+	else
+		echo "Skipping $SERVICE"
+	fi
 
-    if ! env | grep "DISABLE_${SERVICEUC}=true" >/dev/null 2>&1; then
+  else
+	if [ $CONTINUE ]; then
+
       curl -s -o ${L} https://raw.githubusercontent.com/uklans/cache-domains/master/${L}
     	## files don't have a newline at the end
     	echo "" >> ${L}
-    	cat ${L} | grep -v "^#" | while read URL; do
-      	if [ "x${URL}" != "x" ] ; then
-          ## remove the *. from the begging if it's there.
-          URL=$(echo ${URL} | sed 's/^\*\.//;s/,//g')
-          if ! grep "${URL}" ${CACHECONF} 1>/dev/null 2>&1; then
-            if [ "$USE_GENERIC_CACHE" = "true" ] && ! [ -z "${C_IP}" ] ; then
-              echo "zone \"${URL}\" in { type master; file \"/etc/bind/cache/${SERVICE}.db\";};" >> ${CACHECONF}
-              cat ${ZONETEMPLATE} | sed "s/{{DATE}}/$(date +%Y%m%d%M)/;s/{{ service_ip }}/${C_IP}/g" > ${ZONEPATH}/${SERVICE}.db
-            else
-              echo "#ENABLE_${SERVICEUC}#zone \"${URL}\" in { type master; file \"/etc/bind/cache/${SERVICE}.db\";};" >> ${CACHECONF}
-              cat ${ZONETEMPLATE} | sed "s/{{DATE}}/$(date +%Y%m%d%M)/;s/{{ service_ip }}/{{ ${SERVICE}_ip }}/g" > ${ZONEPATH}/${SERVICE}.db
-            fi
-          fi
-      	fi
+		cat ${L} | grep -v "^#" | while read URL; do
+      		if [ "x${URL}" != "x" ] ; then
+				#RPZ entries do NOT need a trailing . on the rpz domain, but do for the redirect host
+				echo "${URL} IN CNAME $SERVICE.$LANCACHE_DNSDOMAIN.;" >> $RPZ_ZONE;
+      		fi
     	done
-      echo "" >> ${CACHECONF}
       rm ${L}
     fi
   fi
@@ -107,36 +150,6 @@ rm services.json
 echo ""
 echo " --- "
 echo ""
-
-enableService() {
-    SERVICE=$1
-    SERVICE_IP=$2
-
-    SERVICE_LC=`echo ${SERVICE} | tr [:upper:] [:lower:]`
-    ZONEFILE="/etc/bind/cache/${SERVICE_LC}.db"
-    echo "creating ${ZONEFILE}"
-
-    if ! [ -z "$SERVICE_IP" ]; then
-        sed -i -e "s%{{ ${SERVICE_LC}_ip }}%${SERVICE_IP}%g" ${ZONEFILE}
-        sed -i -e "s%#ENABLE_${SERVICE}#%%g" ${CACHECONF}
-    fi
-}
-if [ "$USE_GENERIC_CACHE" == "false" ]; then
-
-    env | grep -v LANCACHE_IP | grep "CACHE_IP" | while read SERVICE; do
-
-	    S=$(echo ${SERVICE} | sed 's/CACHE_IP.*//')
-	    I=$(env | grep "${S}CACHE_IP" | sed 's/.*=//')
-	    if ! env | grep "DISABLE_${S}=true" >/dev/null 2>&1; then
-	
-	        if ! [ -z "${S}" ] && ! [ -z "${I}" ]; then
-	            echo "Enabling ${S} on IP ${I}"
-	            enableService ${S} ${I}
-	        fi
-		fi
-
-    done
-fi
 
 if ! [ -z "${UPSTREAM_DNS}" ] ; then
   sed -i "s/#ENABLE_UPSTREAM_DNS#//;s/dns_ip/${UPSTREAM_DNS}/" /etc/bind/named.conf.options


### PR DESCRIPTION
## Background
Steam uses a connection pool to manage download it's files. The library it uses appears to obey the full http spec and limit it's connection pool to 2-4 connections per IP (Not per host). The standard lancache container only has one IP per cdn and as such steams ability to download using multiple connections is restricted resulting in a slower initial download speed.

## Changes
This PR allows multiple IP's to be set for any of the _IP environment variables, for example `STEAMCACHE_IP="10.10.1.30 10.10.1.31"`.

## Testing
This is currently a testing image. If you wish to help out testing please change your steamcache-dns docker command to pull from `steamcache/steamcache-dns:multiple-ips` then carefully follow the tuning guide below. Let us know your results in the comments.

## Tuning your cache
The limitations seen in steam download speed are highly dependent on the latency between your server and the steam cdn servers. In the event you find your initial download speed with the default settings is slow this can be resolved by allocating more IP's to your steamcache. We suggest adding one IP at a time to see how much gain can be had (4 seems to work for a number of people)
### Step 1: Adding IP's to your docker host
Consult your OS documentation in order to add additional IP addresses onto your docker cache host machine
### Step 2: Adding IP's to your cache container
In order for this to work you need to add the port maps onto the relevant cdn container (for example steam). 
* If you are using `steamcache/monolithic` then using `-p 80:80` should be sufficient as per the documentation. 
* If you are using `steamcache/generic` or `steamcache/steamcache` then add multiple `-p <IPadddress>:80:80` for each IP you have added. For example `-p 10.10.1.30:80:80 -p 10.10.1.31:80:80`
### Step 3: Informing steamcache-dns of the extra IP's
Finally we need to inform steamcache-dns that STEAM is now available on multiple IP addresses. This can be done on the command line using the following command `-e STEAMCACHE_IP="10.10.1.30 10.10.1.31"`. Note the quotes surrounding the multiple IP addresses.
### Step 4: Testing
Choose a game which has not been seen by the cache before (or clear your `/data/cache` folder) and start it downloading. Check to see what the maximum speed seen by your steam client is. If necessary repeat steps 1-3 with additional IPs until you see a download equivalent to your uncached steam client or no longer see an improvement vs the previous IP allocation.