### PR TITLE
WIP: change the behavior of ENABLE_DNSSEC_VALIDATION = false

### DIFF
--- a/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
@@ -200,7 +200,7 @@ if [ "${ENABLE_DNSSEC_VALIDATION}" = true ] ; then
 	sed -i "s/dnssec-validation no/dnssec-validation auto/" /etc/bind/named.conf.options
 else
 	echo "Disabling dnssec validation"
-	sed -i "s/dnssec-validation no//" /etc/bind/named.conf.options
+	sed -i "s/dnssec-validation no;//" /etc/bind/named.conf.options
 fi
 
 echo "finished bootstrapping."

--- a/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
@@ -198,6 +198,9 @@ fi
 if [ "${ENABLE_DNSSEC_VALIDATION}" = true ] ; then
 	echo "Enabling dnssec validation"
 	sed -i "s/dnssec-validation no/dnssec-validation auto/" /etc/bind/named.conf.options
+else
+	echo "Disabling dnssec validation"
+	sed -i "s/dnssec-validation no//" /etc/bind/named.conf.options
 fi
 
 echo "finished bootstrapping."


### PR DESCRIPTION
I encountered an issue with the behavior of ENABLE_DNSSEC_VALIDATION = false:

When ```dnssec-validation no``` is set in named.conf, BIND explicitly requests that its upstream DNS server NOT do DNSSEC validation, meaning even if you upstream server is DNSSEC aware and protecting you, BIND will downgrade that protection.

When ```dnssec-validation yes``` is set, BIND does its own validation, even if upstream is properly configured to do the validation itself.  This is both wasteful in a controlled local environment, but my local DNS zones hosted by upstream are not set up for DNSSEC, so they fail validation in lancache-dns.

If instead, ```dnssec-validation``` is omitted from named.conf, it sends normal queries only and does not explicitly request no validation from upstream.  This allows BIND to play nice with upstream that is hosting a local-only (non-DNSSEC) zone, and also acting as a forwarder or recursive resolver.

There's probably a cleaner way to handle this in the generate_config.sh file, but I wasn't sure the best way to handle it - I'm open to suggestions.  Perhaps add a #DNSSEC# flag that gets either replaced with ```dnssec-validation auto;``` if it should be enabled, and removed entirely if it isn't?

I have some screenshots of the wireshark parsing of the DNS queries for all 3 scenarios (when querying a record with intentionally broken DNSSEC) and the results on the client side if it would help.