### PR TITLE
Expose metrics from NGINX and Bind to Prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN git clone --depth=1 --no-single-branch https://github.com/uklans/cache-domai
 
 EXPOSE 53/udp
 EXPOSE 53/tcp
+EXPOSE 8053/tcp
 
 WORKDIR /scripts
 

--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -10,12 +10,17 @@ options {
 	max-cache-ttl 0;
 	max-ncache-ttl 0;
 	forward only;
+	zone-statistics yes;
 	
 	# Permit RFC1918 PTR lookups to be recursed upstream
 	empty-zones-enable no;
 		response-policy { zone "rpz"; };
 		rrset-order { order cyclic; };
         #ENABLE_UPSTREAM_DNS#forwarders { dns_ip; };
+};
+
+statistics-channels {
+    inet 0.0.0.0 port 8053;
 };
 
 logging {


### PR DESCRIPTION
This update is the [lancache-dns](https://github.com/lancachenet/lancache-dns) update for the Bind status export to Prometheus.

Please see https://github.com/lancachenet/docker-compose/issues/38 for further information about this update, as this solves https://github.com/lancachenet/docker-compose/issues/38 

In short, we have added a statistics endpoint, such that Bind data can be exported to Prometheus through [prometheuscommunity/bind-exporter](https://github.com/prometheus-community/bind_exporter).